### PR TITLE
Add option to configure HTTP Basic Auth

### DIFF
--- a/app/controllers/graphiql/rails/editors_controller.rb
+++ b/app/controllers/graphiql/rails/editors_controller.rb
@@ -1,12 +1,27 @@
 module GraphiQL
   module Rails
     class EditorsController < ActionController::Base
+      before_action :authenticate
+
       def show
       end
 
       helper_method :graphql_endpoint_path
       def graphql_endpoint_path
         params[:graphql_path] || raise(%|You must include `graphql_path: "/my/endpoint"` when mounting GraphiQL::Rails::Engine|)
+      end
+
+      private
+
+      def authenticate
+        options = GraphiQL::Rails.config.basic_auth
+
+        return if options.empty? || session[:graphiql_signed_in_at].present?
+
+        session[:graphiql_signed_in_at] = Time.zone.now if authenticate_or_request_with_http_basic(options[:realm] || "Application") { |name, password|
+          ActiveSupport::SecurityUtils.secure_compare(name, options[:name]) &
+          ActiveSupport::SecurityUtils.secure_compare(password, options[:password])
+        }
       end
     end
   end

--- a/lib/graphiql/rails/config.rb
+++ b/lib/graphiql/rails/config.rb
@@ -9,6 +9,11 @@ module GraphiQL
 
       attr_accessor :query_params, :initial_query, :csrf, :title, :logo
 
+      # @example Configuring HTTP Basic Auth
+      #    config.basic_auth = { name: "me", password: "pw" }
+      # @return [Hash<Symbol => String>] Keys must be `:name` and `:password`, `:realm` is optional and defaults to `'Application'`.
+      attr_writer :basic_auth
+
       DEFAULT_HEADERS = {
         'Content-Type' => ->(_) { 'application/json' },
       }
@@ -37,6 +42,10 @@ module GraphiQL
         all_headers.each_with_object({}) do |(key, value), memo|
           memo[key] = value.call(view_context)
         end
+      end
+
+      def basic_auth
+        @basic_auth ||= {}
       end
     end
   end

--- a/test/controllers/editors_controller_test.rb
+++ b/test/controllers/editors_controller_test.rb
@@ -13,6 +13,7 @@ module GraphiQL
         GraphiQL::Rails.config.title = nil
         GraphiQL::Rails.config.logo = nil
         GraphiQL::Rails.config.headers = {}
+        GraphiQL::Rails.config.basic_auth = {}
       end
 
       def graphql_params
@@ -70,6 +71,19 @@ module GraphiQL
         get :show, graphql_params
         assert_includes(@response.body, %(&quot;Nonsense-Header&quot;:&quot;Value&quot;))
         assert_includes(@response.body, %(&quot;X-CSRF-Token&quot;:&quot;))
+      end
+
+      test 'it requires HTTP basic auth' do
+        GraphiQL::Rails.config.basic_auth = { name: 'me', password: 'pw' }
+        get :show, graphql_params
+        assert_equal 401, @response.status
+
+        @request.env['HTTP_AUTHORIZATION'] = ActionController::HttpAuthentication::Basic.encode_credentials(
+          'me',
+          'password',
+        )
+        get :show, graphql_params
+        assert_equal 200, @response.status
       end
     end
   end

--- a/test/graphiql/rails/config_test.rb
+++ b/test/graphiql/rails/config_test.rb
@@ -21,4 +21,10 @@ class ConfigTest < ActiveSupport::TestCase
   test "it adds JSON header by default" do
     assert_equal "application/json", @config.resolve_headers(@view_context)["Content-Type"]
   end
+
+  test "it sets HTTP Basic auth config" do
+    assert_nil @config.basic_auth[:name]
+    @config.basic_auth = { name: "me", password: "pw" }
+    assert_equal "me", @config.basic_auth[:name]
+  end
 end


### PR DESCRIPTION
Background:
In order to rudimentary protect GraphiQL,
this PR adds the option to configure a credentials
for HTTP Basic Auth

Changes:
- Extend config class to store credentials
- A before action in the controller for handles authentication if needed